### PR TITLE
Add preflight checks for macOS compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,21 @@ Activation
 
 ## Installation
 
-```bash
-pip install memory-decay
+> **Python 3.13.11+ 또는 3.10~3.12 권장.** Python 3.13.8은 torch를 깨뜨리는 CPython 버그가 있고, python.org macOS 인스톨러는 sqlite-vec가 필요로 하는 SQLite extension 로딩을 지원하지 않습니다. 자세한 내용은 아래 [macOS 호환성 참고](#macos-compatibility-notes) 참조.
 
-# For local embeddings (sentence-transformers):
-pip install "memory-decay[local]"
+```bash
+# 권장: uv로 Python 버전 고정
+uv venv --python 3.13.11   # 또는 3.10, 3.11, 3.12
+uv pip install memory-decay
+
+# 로컬 임베딩 (sentence-transformers + torch):
+uv pip install "memory-decay[local]"
+```
+
+```bash
+# pip 사용 시
+pip install memory-decay
+pip install "memory-decay[local]"   # 로컬 임베딩용
 ```
 
 ### From Source (Development)
@@ -94,12 +104,28 @@ pip install -e ".[dev]"
 
 ### Dependencies
 
-- Python >= 3.10
+- Python >= 3.10 (3.13.11+ 또는 3.10~3.12 권장)
 - NetworkX, NumPy
 - FastAPI + Uvicorn (server mode)
-- sqlite-vec (vector search persistence)
+- sqlite-vec (vector search persistence — SQLite extension 로딩 지원 필요)
 - Optional: `openai`, `google-genai` (for API-based embeddings)
 - Optional: `sentence-transformers` (for local embeddings, install with `pip install memory-decay[local]`)
+
+### macOS Compatibility Notes
+
+sqlite-vec는 Python이 SQLite loadable extension을 지원해야 하고, local 임베딩은 torch가 정상 import되어야 합니다. macOS에서는 Python 설치 방식에 따라 이 두 가지가 깨질 수 있습니다.
+
+| Python 설치 방식 | sqlite extension 로딩 | torch (local 임베딩) | 비고 |
+|---|---|---|---|
+| **uv** (python-build-standalone) | O | O | 권장 |
+| **homebrew** | O | O* | *3.13.8은 torch 불가 |
+| **pyenv** | O | O | 소스 빌드, 플래그 포함 |
+| **python.org 인스톨러** | **X** | O | `--enable-loadable-sqlite-extensions` 누락 |
+
+**알려진 이슈:**
+
+- **Python 3.13.8 + torch**: CPython 3.13.8의 `ast.parse()` 리그레션이 torch import를 깨뜨림 ([pytorch/pytorch#178255](https://github.com/pytorch/pytorch/issues/178255)). Python 3.13.11+에서 수정됨.
+- **python.org macOS 인스톨러 + sqlite-vec**: 공식 macOS 인스톨러가 SQLite extension 로딩 없이 빌드됨. uv, homebrew, 또는 pyenv를 사용할 것.
 
 ## Quick Start
 

--- a/docs/superpowers/specs/2026-03-27-session-handoff-design.md
+++ b/docs/superpowers/specs/2026-03-27-session-handoff-design.md
@@ -54,9 +54,19 @@ The result is stored as a memory the next session can retrieve.
 | `memory_id` | ID of the stored session_summary memory |
 | `memories_included` | Count of individual memories used to build the summary |
 
+### Parameter Validation
+
+| Field | Validation |
+|-------|------------|
+| `hours` | Must be positive integer (> 0). Default is 24. |
+| `min_activation` | Must be in [0.0, 1.0]. Default 0.1. |
+| `top_k` | Must be positive integer (> 0). Default 50. |
+
+Invalid parameters return HTTP 422 with a descriptive error.
+
 ### Behavior
 
-1. **Query** recent memories from the last `hours` with `activation >= min_activation`
+1. **Query** recent memories from the last `hours` with `activation >= min_activation`, ordered by activation descending, limited to `top_k`
 2. **Group** by category:
    - `task` / `episode` → **Active Tasks**
    - `decision` → **Recent Decisions**
@@ -70,11 +80,37 @@ The result is stored as a memory the next session can retrieve.
    - `content`: the summary text
 5. **Return** the summary text, memory ID, and count of included memories
 
+### Error Handling
+
+| Condition | Response |
+|-----------|----------|
+| Query yields 0 memories | HTTP 200 with `{"summary": "## Session Handoff\n\nNo active memories found.", "memory_id": "sess_<uuid>", "memories_included": 0}` — still stores an empty summary |
+| Storage fails | HTTP 500 — the endpoint must succeed in storing the summary; callers depend on having it retrievable |
+| Invalid parameters | HTTP 422 with validation error details |
+
+### Example
+
+**Request:** `POST /session-summary` with default params, 3 relevant memories in store.
+
+**Memories found:**
+- `{"id": "m1", "category": "task", "content": "Fix auth middleware", "activation": 0.85}`
+- `{"id": "m2", "category": "decision", "content": "Chose SQLite over Postgres", "activation": 0.72}`
+- `{"id": "m3", "category": "preference", "content": "User prefers dark mode", "activation": 0.60}`
+
+**Response:**
+```json
+{
+  "summary": "## Session Handoff\n\n### Active Tasks\n- Fix auth middleware\n\n### Recent Decisions\n- Chose SQLite over Postgres\n\n### Current Context\n- User prefers dark mode",
+  "memory_id": "sess_abc123",
+  "memories_included": 3
+}
+```
+
 ### Storage Memory Properties
 
 The stored session_summary memory uses:
 - `mtype=fact` — decays slowly (lambda_fact=0.02)
-- `importance=0.95` — near maximum, so it stays near the activation floor
+- `importance=0.95` — near the ceiling of the soft-floor formula `A(t+1) = floor(impact) + (A(t) - floor(impact)) * exp(-rate)`, so it converges toward 0.95 as the activation floor and remains highly retrievable
 - `category=session_summary` — searchable via `/search` with category filter
 
 This means the handoff summary persists across ticks and is easy to retrieve at session start.
@@ -97,6 +133,14 @@ This keeps memory-decay-core focused on storage and retrieval; session lifecycle
 - It does NOT replace memories — the original memories remain in the store with their own decay
 - It does NOT do LLM summarization — the summary is structured grouping, not generative compression
 - It does NOT handle timer logic — that is the plugin's responsibility
+
+---
+
+## What This Assumes
+
+- The memory store is already populated with relevant memories before the endpoint is called
+- `min_activation` is tuned to the deployed decay curve — if the tick interval is very short (e.g., minutes), memories decay faster and `min_activation` should be lowered accordingly
+- Plugins retrieve the last session_summary via `/search` with `category=session_summary` and `top_k=1` ordered by `created_tick` descending
 
 ---
 

--- a/docs/superpowers/specs/2026-03-27-session-handoff-design.md
+++ b/docs/superpowers/specs/2026-03-27-session-handoff-design.md
@@ -1,0 +1,120 @@
+# Session Handoff Summary — Design
+
+## Status
+
+Approved for planning.
+
+## Background
+
+The **session amnesia problem** is acute in OpenClaw because sessions are long-running and multi-step. When an agent resumes after a break, it has no automatic way to reconstruct context — it either starts from scratch or the user re-explains everything.
+
+The current memory-decay system handles storage and retrieval well, but lacks a mechanism for **structured session context transfer** between sessions.
+
+## Goal
+
+Provide a single endpoint that a consuming agent (openclaw-memory-decay, claude-code-memory-decay) can call at:
+- **Session end** — capture final state
+- **Periodic intervals** — capture state every N hours during long sessions
+
+The result is stored as a memory the next session can retrieve.
+
+---
+
+## API: `POST /session-summary`
+
+### Request
+
+```json
+{
+  "hours": 24,
+  "min_activation": 0.1,
+  "top_k": 50
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `hours` | 24 | How far back to look for recent memories |
+| `min_activation` | 0.1 | Skip memories with activation below this threshold |
+| `top_k` | 50 | Maximum number of memories to include |
+
+### Response
+
+```json
+{
+  "summary": "## Session Handoff\n\n### Active Tasks\n- ...\n\n### Recent Decisions\n- ...\n\n### Current Context\n- ...",
+  "memory_id": "sess_<uuid>",
+  "memories_included": 12
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `summary` | Markdown-formatted handoff text |
+| `memory_id` | ID of the stored session_summary memory |
+| `memories_included` | Count of individual memories used to build the summary |
+
+### Behavior
+
+1. **Query** recent memories from the last `hours` with `activation >= min_activation`
+2. **Group** by category:
+   - `task` / `episode` → **Active Tasks**
+   - `decision` → **Recent Decisions**
+   - `fact` / `preference` → **Current Context**
+3. **Format** into a markdown handoff summary with the structure above
+4. **Store** as a new memory:
+   - `memory_id`: `sess_<uuid>`
+   - `mtype`: `fact`
+   - `category`: `session_summary`
+   - `importance`: `0.95`
+   - `content`: the summary text
+5. **Return** the summary text, memory ID, and count of included memories
+
+### Storage Memory Properties
+
+The stored session_summary memory uses:
+- `mtype=fact` — decays slowly (lambda_fact=0.02)
+- `importance=0.95` — near maximum, so it stays near the activation floor
+- `category=session_summary` — searchable via `/search` with category filter
+
+This means the handoff summary persists across ticks and is easy to retrieve at session start.
+
+---
+
+## Trigger Logic (Plugin Layer)
+
+Timer-based triggering is **not** implemented in memory-decay-core. It lives in the consuming agent:
+
+- **openclaw-memory-decay** / **claude-code-memory-decay**: call `POST /session-summary` on session-end event and on a periodic timer (e.g., every N hours)
+- The plugin also calls `GET /search` with `category=session_summary` at session start to retrieve the last handoff
+
+This keeps memory-decay-core focused on storage and retrieval; session lifecycle management stays in the plugin.
+
+---
+
+## What This Does NOT Do
+
+- It does NOT replace memories — the original memories remain in the store with their own decay
+- It does NOT do LLM summarization — the summary is structured grouping, not generative compression
+- It does NOT handle timer logic — that is the plugin's responsibility
+
+---
+
+## Open Questions
+
+None at this time.
+
+---
+
+## Alternatives Considered
+
+**B: Utility class `SessionSummaryGenerator`**
+- Core provides a class, plugin calls it and stores the result
+- More flexible but adds integration burden per plugin
+- Rejected in favor of self-contained endpoint
+
+**C: New memory type + query helpers**
+- Expose `get_active_tasks()`, `get_recent_decisions()` helpers
+- Plugin assembles the summary
+- Adds complexity without reducing plugin burden
+- Rejected

--- a/src/memory_decay/embedding_provider.py
+++ b/src/memory_decay/embedding_provider.py
@@ -91,7 +91,17 @@ class LocalEmbeddingProvider(EmbeddingProvider):
 
     def _ensure_model(self):
         if self._st_model is None:
-            from sentence_transformers import SentenceTransformer
+            try:
+                from sentence_transformers import SentenceTransformer
+            except ImportError as e:
+                raise RuntimeError(
+                    "sentence-transformers is required for local embeddings but failed to import.\n"
+                    f"Underlying error: {e}\n\n"
+                    "Install with: pip install 'memory-decay[local]'\n\n"
+                    "If already installed and using Python 3.13.x, note that CPython 3.13.8 "
+                    "has an ast.parse() regression that breaks torch (pytorch/pytorch#178255).\n"
+                    "Fix: upgrade to Python 3.13.11+ or use Python 3.10-3.12."
+                ) from e
             self._st_model = SentenceTransformer(self._model_name)
             self._dim = self._st_model.get_sentence_embedding_dimension()
 

--- a/src/memory_decay/memory_store.py
+++ b/src/memory_decay/memory_store.py
@@ -49,10 +49,33 @@ class MemoryStore:
         self._db.row_factory = sqlite3.Row
         self._db.execute("PRAGMA journal_mode=WAL")
         self._db.execute("PRAGMA synchronous=NORMAL")
-        self._db.enable_load_extension(True)
-        sqlite_vec.load(self._db)
-        self._db.enable_load_extension(False)
+        self._load_sqlite_vec()
         self._init_schema()
+
+    def _load_sqlite_vec(self) -> None:
+        """Load sqlite-vec extension with clear error on unsupported Python builds."""
+        if not hasattr(self._db, "enable_load_extension"):
+            raise RuntimeError(
+                "This Python build does not support SQLite loadable extensions "
+                "(sqlite3.Connection.enable_load_extension is missing).\n"
+                "This is required for sqlite-vec vector search.\n\n"
+                "Common cause: python.org macOS installer builds Python without "
+                "--enable-loadable-sqlite-extensions.\n\n"
+                "Fix: use one of these Python builds instead:\n"
+                "  - uv: uv venv --python 3.10  (recommended)\n"
+                "  - homebrew: brew install python@3.12\n"
+                "  - pyenv: pyenv install 3.12.8"
+            )
+        try:
+            self._db.enable_load_extension(True)
+            sqlite_vec.load(self._db)
+            self._db.enable_load_extension(False)
+        except AttributeError:
+            raise RuntimeError(
+                "Failed to enable SQLite loadable extensions. "
+                "Your Python's sqlite3 module was compiled without extension support.\n\n"
+                "Fix: use uv (uv venv --python 3.10) or homebrew Python."
+            )
 
     def _init_schema(self) -> None:
         # Create non-vector tables first

--- a/src/memory_decay/server.py
+++ b/src/memory_decay/server.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import json
+import sys
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -471,6 +472,51 @@ def create_app(
 
 
 # ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+
+def _preflight_checks(embedding_provider: str) -> None:
+    """Validate environment before starting the server."""
+    import sqlite3 as _sqlite3
+
+    # Check sqlite extension support
+    conn = _sqlite3.connect(":memory:")
+    try:
+        if not hasattr(conn, "enable_load_extension"):
+            print(
+                "ERROR: This Python build does not support SQLite loadable extensions.\n"
+                "sqlite-vec requires sqlite3.Connection.enable_load_extension().\n\n"
+                "Common cause: python.org macOS installer builds Python without\n"
+                "--enable-loadable-sqlite-extensions.\n\n"
+                "Fix: use one of these Python builds instead:\n"
+                "  - uv: uv venv --python 3.10  (recommended)\n"
+                "  - homebrew: brew install python@3.12\n"
+                "  - pyenv: pyenv install 3.12.8",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    finally:
+        conn.close()
+
+    # Check torch/sentence-transformers for local provider
+    if embedding_provider == "local":
+        try:
+            import torch  # noqa: F401
+        except Exception as e:
+            print(
+                f"ERROR: Failed to import torch (required for local embeddings).\n"
+                f"Underlying error: {e}\n\n"
+                f"If using Python 3.13.x, CPython 3.13.8 has an ast.parse() regression\n"
+                f"that breaks torch (pytorch/pytorch#178255).\n"
+                f"Fix: upgrade to Python 3.13.11+ or use Python 3.10-3.12.\n\n"
+                f"Current Python: {sys.version}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
 
@@ -499,6 +545,8 @@ def main():
     parser.add_argument("--workers", type=int, default=1,
                         help="Number of uvicorn workers (default: 1)")
     args = parser.parse_args()
+
+    _preflight_checks(args.embedding_provider)
 
     provider = create_embedding_provider(
         provider=args.embedding_provider,

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,109 @@
+"""Tests for preflight checks and clear error messages."""
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from memory_decay.memory_store import MemoryStore
+
+
+class TestSqliteExtensionCheck:
+    def test_missing_enable_load_extension_raises_runtime_error(self):
+        """MemoryStore must raise RuntimeError with clear message when
+        enable_load_extension is not available."""
+        mock_conn = MagicMock(spec=[])  # empty spec = no attributes
+        mock_conn.execute = MagicMock()
+        mock_conn.row_factory = None
+
+        with patch("sqlite3.connect", return_value=mock_conn):
+            with pytest.raises(RuntimeError, match="SQLite loadable extensions"):
+                MemoryStore(":memory:", embedding_dim=8)
+
+    def test_error_message_mentions_python_org_installer(self):
+        """Error message should guide macOS users away from python.org installer."""
+        mock_conn = MagicMock(spec=[])
+        mock_conn.execute = MagicMock()
+        mock_conn.row_factory = None
+
+        with patch("sqlite3.connect", return_value=mock_conn):
+            with pytest.raises(RuntimeError, match="python.org"):
+                MemoryStore(":memory:", embedding_dim=8)
+
+    def test_error_message_suggests_uv(self):
+        """Error message should recommend uv as a fix."""
+        mock_conn = MagicMock(spec=[])
+        mock_conn.execute = MagicMock()
+        mock_conn.row_factory = None
+
+        with patch("sqlite3.connect", return_value=mock_conn):
+            with pytest.raises(RuntimeError, match="uv venv"):
+                MemoryStore(":memory:", embedding_dim=8)
+
+    def test_normal_init_works(self):
+        """MemoryStore should still work normally when extensions are supported."""
+        store = MemoryStore(":memory:", embedding_dim=8)
+        assert store.num_memories == 0
+        store.close()
+
+
+class TestLocalEmbeddingProviderCheck:
+    def test_import_failure_raises_runtime_error(self):
+        """LocalEmbeddingProvider should raise RuntimeError with guidance
+        when sentence_transformers import fails."""
+        from memory_decay.embedding_provider import LocalEmbeddingProvider
+
+        provider = LocalEmbeddingProvider()
+
+        with patch.dict("sys.modules", {"sentence_transformers": None}):
+            with pytest.raises(RuntimeError, match="sentence-transformers"):
+                provider.embed("test")
+
+    def test_error_mentions_python_313_regression(self):
+        """Error message should mention CPython 3.13.8 AST regression."""
+        from memory_decay.embedding_provider import LocalEmbeddingProvider
+
+        provider = LocalEmbeddingProvider()
+
+        with patch.dict("sys.modules", {"sentence_transformers": None}):
+            with pytest.raises(RuntimeError, match="3.13"):
+                provider.embed("test")
+
+
+class TestServerPreflightChecks:
+    def test_sqlite_check_fails_gracefully(self):
+        """_preflight_checks should sys.exit(1) when sqlite extensions missing."""
+        from memory_decay.server import _preflight_checks
+
+        mock_conn = MagicMock(spec=[])  # no enable_load_extension
+        mock_conn.close = MagicMock()
+
+        with patch("sqlite3.connect", return_value=mock_conn):
+            with pytest.raises(SystemExit) as exc_info:
+                _preflight_checks("local")
+            assert exc_info.value.code == 1
+
+    def test_torch_import_check_fails_gracefully(self):
+        """_preflight_checks should sys.exit(1) when torch import fails."""
+        from memory_decay.server import _preflight_checks
+
+        def mock_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("No module named 'torch'")
+            return original_import(name, *args, **kwargs)
+
+        import builtins
+        original_import = builtins.__import__
+
+        with patch.object(builtins, "__import__", side_effect=mock_import):
+            with pytest.raises(SystemExit) as exc_info:
+                _preflight_checks("local")
+            assert exc_info.value.code == 1
+
+    def test_preflight_passes_for_nonlocal_provider(self):
+        """_preflight_checks should not check torch for non-local providers."""
+        from memory_decay.server import _preflight_checks
+
+        # Should not raise for gemini/openai even if torch is missing
+        _preflight_checks("gemini")
+        _preflight_checks("openai")


### PR DESCRIPTION
## Summary

- MemoryStore에 sqlite extension 로딩 사전 검증 추가 — `enable_load_extension` 미지원 시 원인과 해결 방법을 명확히 안내
- LocalEmbeddingProvider에 sentence-transformers import 실패 시 Python 3.13.8 AST 리그레션 안내 추가
- 서버 시작 전 `_preflight_checks()` — sqlite extension 지원 + torch import를 서버 시작 전에 검증
- README에 macOS 호환성 매트릭스 및 권장 설치 방법 추가

## Context

macOS 환경에서 Python 설치 방식에 따라 서버 시작이 실패하는 보고가 있었습니다:
1. python.org macOS 인스톨러 — `--enable-loadable-sqlite-extensions` 빌드 플래그 누락
2. Python 3.13.8 — CPython `ast.parse()` 리그레션으로 torch import 실패 (pytorch/pytorch#178255)

두 문제 모두 upstream 환경 문제로 코드 레벨 근본 수정은 불가하나, 사전 검증과 명확한 에러 메시지로 사용자 경험을 개선합니다.

## Test plan

- [x] 9개 새 preflight 테스트 추가 (mock 기반)
- [x] 기존 전체 테스트 114개 통과 확인
- [ ] macOS python.org 인스톨러에서 에러 메시지 확인
- [ ] Python 3.13.8 homebrew에서 에러 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)